### PR TITLE
Rename the time_index column to time

### DIFF
--- a/mlprimitives/adapters/featuretools.py
+++ b/mlprimitives/adapters/featuretools.py
@@ -82,6 +82,7 @@ class DFS(object):
         cutoff_time = None
         if self.time_index:
             cutoff_time = X[[self.index, self.time_index]]
+            cutoff_time = cutoff_time.rename(columns={self.time_index: 'time'})
 
         self.features = ft.dfs(
             cutoff_time=cutoff_time,
@@ -125,6 +126,7 @@ class DFS(object):
         cutoff_time = None
         if self.time_index:
             cutoff_time = X[[self.index, self.time_index]]
+            cutoff_time = cutoff_time.rename(columns={self.time_index: 'time'})
 
         X = ft.calculate_feature_matrix(
             self.features,


### PR DESCRIPTION
From [featuretools v0.15](https://github.com/alteryx/featuretools/releases/tag/v0.15.0) onwards:

> Calls to `featuretools.dfs` or `featuretools.calculate_feature_matrix` that use a cutoff time
dataframe, but do not label the `time` column with either the target entity time index variable name or
as `time`, will now result in an `AttributeError`.

In order to work around this and continue to support cutoff time indexes called differently, this PR adds a renaming step after building the cutoff dataframe to ensure that the time index is called `time` when the dataframe is passed to `dfs` and `calculate_feature_matrix`.