### PR TITLE
Keras adapter with uni-dimensional targets

### DIFF
--- a/mlprimitives/adapters/keras.py
+++ b/mlprimitives/adapters/keras.py
@@ -87,7 +87,11 @@ class Sequential(object):
 
     def _augment_hyperparameters(self, X, mode, kwargs):
         shape = np.asarray(X)[0].shape
-        length = shape[0]
+        if shape:
+            length = shape[0]
+        else:
+            length = 1  # supporting shape (l, )
+
         self._setdefault(kwargs, '{}_shape'.format(mode), shape)
         self._setdefault(kwargs, '{}_dim'.format(mode), length)
         self._setdefault(kwargs, '{}_length'.format(mode), length)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ development_requires = [
     'm2r>=0.2.0,<0.3',
     'Sphinx>=1.7.1,<3',
     'sphinx_rtd_theme>=0.2.4,<0.5',
+    'docutils>=0.14,<0.18',
     'ipython>=6.5.0',
 
     # style check


### PR DESCRIPTION
Resolve #265. 

Pinned `docutils<18` due to the new release breaking `sphinx`.