### PR TITLE
 ``SimpleImputer`` primitive update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade "pip<=24.1" setuptools wheel
         pip install .[dev]
     - name: make test-devel
       run: make test-devel

--- a/mlprimitives/primitives/sklearn.impute.SimpleImputer.json
+++ b/mlprimitives/primitives/sklearn.impute.SimpleImputer.json
@@ -45,10 +45,6 @@
                 "type": "str, int or float",
                 "default": null
             },
-            "verbose": {
-                "type": "bool",
-                "default": false
-            },
             "copy": {
                 "type": "bool",
                 "default": true


### PR DESCRIPTION
`verbose` argument is deprecated for `SimpleImputer` 